### PR TITLE
Get one Candidate

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -5,11 +5,6 @@ module Types
     # Add root-level fields here.
     # They will be entry points for queries on your schema.
 
-    field :getCandidate
-          [Types::CandidateType],
-          null: false,
-          description: "Returns a single candidate by id"
-
     field :hello_world, # name of method
           String, # Type the data will be
           null: false, # If it can ever return a null value


### PR DESCRIPTION
Adds functionality for getting a single candidate by id

Example request:
```
query getCandidate {
    candidate(id: 1) { 
        id
        firstName
        lastName
        email
    }
 }
```

Expected Response:
```
{
  "data": {
    "candidate": {
      "id": "1",
      "firstName": "Mary",
      "lastName": "Jane",
      "email": "mary.jane@vangst.com"
    }
  }
}
```

Ran into some blockers trying to pass the `id` argument, used a solution similar to what I found [here](https://stackoverflow.com/questions/50976093/in-graphql-rails-how-to-pass-arguments-in-the-query-type)

Also spent too much time not realizing the `id` was being returned as a hash (it's always the little things)

Closes #4 