### PR TITLE
Get one job application

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'rspec-rails'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'pry'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     database_cleaner (1.8.5)
@@ -100,6 +101,9 @@ GEM
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     pg (1.2.3)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.3)
@@ -211,6 +215,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg
+  pry
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
   rspec-rails

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -15,8 +15,17 @@ module Types
       argument :id, ID, required: true
     end
 
+    field :jobApplications, JobApplicationType, null: true do
+      description "Find a single job application by its' id"
+      argument :id, ID, required: true
+    end
+
     def candidate(id)
       Candidate.find(id[:id])
+    end
+
+    def jobApplications(id)
+      JobApplication.find(id[:id])
     end
 
     def hello_world


### PR DESCRIPTION
Adds query to find a single job application by id

Example Request:
```
query getJobApplications {
    jobApplications(id: 1) { 
        id
        jobPostingId
        candidateId
    }
 }
```

Expected Response:
```
{
  "data": {
    "jobApplications": {
      "id": "1",
      "jobPostingId": 1,
      "candidateId": 1
    }
  }
}
```

Used [this](https://evilmartians.com/chronicles/graphql-on-rails-1-from-zero-to-the-first-query) tutorial to help guide my coding, was very similar in nature to #4 so it didn't end up being too hard to figure out

Closes #5 