### PR TITLE
Get active jobs (WIP)

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,12 +11,21 @@ module Types
           description: 'An example field added for your reference!' # Optional Descriotion
 
     field :candidate, CandidateType, null: true do
-      description 'test'
+      description 'Gets a single candidate'
       argument :id, ID, required: true
+    end
+
+    field :job_applications, JobApplicationType, null: true do
+      description 'Gets active job applications'
+      argument :isActive, Boolean, required: true
     end
 
     def candidate(id)
       Candidate.find(id[:id])
+    end
+
+    def job_applications(isActive)
+      JobApplication.where(is_active: isActive)
     end
 
     def hello_world


### PR DESCRIPTION
I've run into some hurdles with both this (#7) card and card #6 due to a very similar error that I have been struggling to figure out
```
          Failed to implement JobApplication.id, tried:

          - `Types::JobApplicationType#id`, which did not exist
          - `JobApplication::ActiveRecord_Relation#id`, which did not exist
          - Looking up hash key `:id` or `"id"` on `#<JobApplication::ActiveRecord_Relation:0x00007ffb3c000930>`, but it wasn't a Hash

          To implement this field, define one of the methods above (and check for typos)
```
The main issue I think that I am facing is unfamiliarity with graphql, specifically how it handles objects.  I'm not sure where it is getting the JobApplication object that it is try to get `id` from.

It seems like it is trying to pull the id from the table itself and I can't seem to just pass it the object that I want to.

I have double checked my active record calls both in a pry session and using rails c, and I know the active record in the `job_applications` method is returning the correct applications (shown below)

<img width="1329" alt="Screen Shot 2020-09-03 at 9 51 56 AM" src="https://user-images.githubusercontent.com/42710030/92138242-5e08cb00-edcb-11ea-984d-0b76c9179507.png">


